### PR TITLE
[CI test] Verify cleanup-ci-w22712082 workflows trigger correctly

### DIFF
--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -4,7 +4,7 @@
 warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lines_of_code > 1000
 
 # Redirect contributors to PR to dev.
-fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev"
+fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev" && github.branch_for_base != "cleanup-ci-w22712082"
 
 # List of supported xcode schemes for testing
 SCHEMES = ['SalesforceSDKCommon', 'SalesforceAnalytics', 'SalesforceSDKCore', 'SmartStore', 'MobileSync']

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target is used so secrets are available to fork PRs.
   # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    branches: [dev, master, cleanup-ci-w22712082]
 
 permissions:
   contents: read

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiver.swift
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiver.swift
@@ -1,3 +1,4 @@
+// CI test trigger for W-22712082; revert before merge.
 /*
  SalesforceLogReceiver.swift
  SalesforceSDKCommon


### PR DESCRIPTION
## Purpose

Test PR to exercise the new `cleanup-ci-w22712082` workflow files before opening the upstream PR (W-22712082).

This PR is internal to the fork — it triggers `pull_request_target` on `cleanup-ci-w22712082` so the new workflows execute against a real source change.

## What's in the diff

- `.github/workflows/pr.yaml`: temporarily extend `branches:` filter to include `cleanup-ci-w22712082` so this test PR triggers CI. Reverted before upstream PR.
- `.github/DangerFiles/TestOrchestrator.rb`: relax the dev-base requirement for this test branch only. Reverted before upstream PR.
- `libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiver.swift`: trivial comment to drive the orchestrator to select SalesforceSDKCommon for testing. Reverted before upstream PR.

## Acceptance

CI must succeed on this PR (or fail only for environmental/secret reasons unrelated to the workflow changes). Once green, the upstream PR for the underlying `cleanup-ci-w22712082` branch can be opened against forcedotcom:dev.

DO NOT MERGE — for CI verification only.